### PR TITLE
Added Query.connect method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 .env
+package-lock.json

--- a/src/app/index.js
+++ b/src/app/index.js
@@ -107,14 +107,14 @@ class App
      * On connection timeout.
      */
     onTimeout() {
-
+        this.viewer.ts3.query.connect();
     }
 
     /**
      * On connection closed.
      */
     onClose() {
-
+        this.viewer.ts3.query.connect();
     }
 }
 

--- a/src/query/Query.js
+++ b/src/query/Query.js
@@ -14,14 +14,11 @@ class Query extends EventEmitter
         super();
 
         this.socket = new Telnet();
-        this.socket.connect({
-            host,
-            port,
-            shellPrompt: 'Welcome to the TeamSpeak 3 ServerQuery interface, type "help" for a list of commands and "help <command>" for information on a specific command.',
-            irs: "\n\r",
-            echoLines: -1,
-            timeout: 600000,
-        });
+
+        this.host = host;
+        this.port = port;
+
+        this.connect();
 
         this.initEvents();
     }
@@ -64,6 +61,22 @@ class Query extends EventEmitter
         this.socket.on('ready', this.onReady.bind(this));
         this.socket.on('timeout', this.onTimeout.bind(this));
         this.socket.on('close', this.onClose.bind(this));
+    }
+
+    /**
+     * Connect to telnet socket.
+     */
+    connect() {
+        const { host, port } = this;
+
+        this.socket.connect({
+            host,
+            port,
+            shellPrompt: 'Welcome to the TeamSpeak 3 ServerQuery interface, type "help" for a list of commands and "help <command>" for information on a specific command.',
+            irs: "\n\r",
+            echoLines: -1,
+            timeout: 600000,
+        });
     }
 
     /**


### PR DESCRIPTION
Closes #3.

call `Query.connect` when the connection either closes or times out.

Tested timeout using firewall to block requests.

Tested close by called `Socket.end` after 1 second of starting the application.